### PR TITLE
Implement tech tree UI toggle functionality and update game state management

### DIFF
--- a/Common/UI/speed_controls/speed_controls.gd
+++ b/Common/UI/speed_controls/speed_controls.gd
@@ -107,7 +107,8 @@ func _update_button_states() -> void:
     speed_4x_button.button_pressed = true
 
 func _on_pause_pressed() -> void:
-  GameManager.toggle_pause()
+  if GameManager.is_playing():
+    GameManager.toggle_pause()
 
 func _on_speed_1x_pressed() -> void:
   GameManager.set_game_speed(1.0)

--- a/Stages/UI/main_ui/ui.gd
+++ b/Stages/UI/main_ui/ui.gd
@@ -12,6 +12,8 @@ signal obstacle_spawn_requested(obstacle: Resource_ObstacleType)
 func _process(_delta: float) -> void:
   if Input.is_action_just_pressed("toggle_in_game_menu"):
     GameManager.toggle_in_game_menu()
+  elif Input.is_action_just_pressed("toggle_tech_tree"):
+    _toggle_tech_tree()
   elif Input.is_action_just_pressed("toggle_stats"):
     _toggle_stats_display()
   elif Input.is_action_just_pressed("toggle_fps"):
@@ -46,6 +48,15 @@ func _on_wave_completed(wave: System_Wave, wave_number: int) -> void:
 func show_obstacle_removed(refund_amount: int) -> void:
   if spawn_indicator and spawn_indicator.has_method("show_obstacle_removed"):
     spawn_indicator.show_obstacle_removed(refund_amount)
+
+## Toggle the tech tree UI visibility
+func _toggle_tech_tree() -> void:
+  MyLogger.info("UI", "Toggling Tech Tree UI")
+  if GameManager.current_state == GameManager.GameState.IN_TECH_TREE:
+    GameManager.set_game_state(GameManager.GameState.PLAYING)
+  else:
+    GameManager.pause_game()
+    GameManager.set_game_state(GameManager.GameState.IN_TECH_TREE)
 
 ## Toggle the stats display visibility
 func _toggle_stats_display() -> void:

--- a/Stages/UI/main_ui/ui.tscn
+++ b/Stages/UI/main_ui/ui.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=18 format=3 uid="uid://duje032qpuq2"]
+[gd_scene load_steps=19 format=3 uid="uid://duje032qpuq2"]
 
 [ext_resource type="Script" uid="uid://3yfu45cvudar" path="res://Stages/UI/main_ui/ui.gd" id="1_27fn8"]
 [ext_resource type="Theme" uid="uid://b8k2vgj8hxk5r" path="res://Config/ztd_ui_theme.tres" id="2_theme"]
 [ext_resource type="PackedScene" uid="uid://bomn53pg4n868" path="res://Stages/UI/game_over/game_over_menu.tscn" id="3_h1vkl"]
+[ext_resource type="PackedScene" uid="uid://b7rnv4gqf8q7o" path="res://Stages/UI/tech_tree/tech_tree.tscn" id="3_r1fny"]
 [ext_resource type="PackedScene" uid="uid://bhnpr8mat2j5c" path="res://Common/UI/currency_display/currency_display.tscn" id="4_currency"]
 [ext_resource type="PackedScene" uid="uid://cmjoofmc48ms1" path="res://Stages/UI/victory/victory_menu.tscn" id="4_vg0vb"]
 [ext_resource type="PackedScene" uid="uid://dqn8xvlx7m8kb" path="res://Common/UI/spawn_indicator/spawn_indicator.tscn" id="5_spawn_indicator"]
@@ -101,7 +102,7 @@ anchor_right = 0.135
 anchor_bottom = 0.205
 offset_left = 663.0
 offset_top = 502.0
-offset_right = 507.48
+offset_right = 507.47998
 offset_bottom = 369.16
 script = ExtResource("15_y1b7e")
 
@@ -110,6 +111,10 @@ layout_mode = 0
 offset_right = 16.0
 offset_bottom = 12.0
 text = "Free Scrap"
+
+[node name="TechTree" parent="." instance=ExtResource("3_r1fny")]
+visible = false
+layout_mode = 1
 
 [connection signal="obstacle_selected" from="Hotbar" to="." method="request_obstacle_spawn"]
 [connection signal="pressed" from="DebugControl/FreeScrap" to="DebugControl" method="_on_free_scrap_pressed"]

--- a/Stages/UI/pause_menu/pause_menu.gd
+++ b/Stages/UI/pause_menu/pause_menu.gd
@@ -2,11 +2,9 @@ extends Control
 class_name UI_PauseMenu
 
 const SettingsMenuScene = preload("res://Common/UI/settings_menu/settings_menu.tscn")
-const TechTreeScene = preload("res://Stages/UI/tech_tree/tech_tree.tscn")
 const AchievementListScene = preload("res://Stages/UI/achievement_list/achievement_list.tscn")
 
 @onready var resume_button: Button = $VBoxContainer/ResumeButton
-@onready var tech_tree_button: Button = $VBoxContainer/TechTreeButton
 @onready var achievements_button: Button = $VBoxContainer/AchievementsButton
 @onready var settings_button: Button = $VBoxContainer/SettingsButton
 @onready var restart_button: Button = $VBoxContainer/RestartButton
@@ -14,7 +12,6 @@ const AchievementListScene = preload("res://Stages/UI/achievement_list/achieveme
 @onready var quit_button: Button = $VBoxContainer/QuitButton
 
 var settings_menu = null
-var tech_tree_ui = null
 var achievement_list_ui = null
 
 func _ready():
@@ -35,19 +32,14 @@ func _setup_settings_menu():
 func _on_game_state_changed(new_state: GameManager.GameState):
   match new_state:
     GameManager.GameState.IN_GAME_MENU:
-      show_menu()
+      visible = true
+      # Focus the resume button for keyboard navigation
+      resume_button.grab_focus()
     GameManager.GameState.PLAYING:
-      hide_menu()
-
-func show_menu():
-  visible = true
-  # Focus the resume button for keyboard navigation
-  resume_button.grab_focus()
-
-func hide_menu():
-  visible = false
+      visible = false
 
 func _on_resume_pressed():
+  MyLogger.info("PauseMenu", "Resume button pressed")
   GameManager.toggle_in_game_menu()
 
 func _on_settings_pressed():
@@ -55,22 +47,6 @@ func _on_settings_pressed():
   if settings_menu:
     settings_menu.show_menu()
 
-func _on_tech_tree_pressed():
-  MyLogger.info("PauseMenu", "Tech Tree button pressed")
-  _show_tech_tree()
-
-func _show_tech_tree():
-  # Create tech tree UI if not already open
-  if tech_tree_ui == null:
-    tech_tree_ui = TechTreeScene.instantiate()
-    add_child(tech_tree_ui)
-    tech_tree_ui.closed.connect(_on_tech_tree_closed)
-  else:
-    tech_tree_ui.visible = true
-
-func _on_tech_tree_closed():
-  MyLogger.debug("PauseMenu", "Tech tree closed")
-  tech_tree_ui = null
 
 func _on_achievements_pressed():
   MyLogger.info("PauseMenu", "Achievements button pressed")

--- a/Stages/UI/pause_menu/pause_menu.tscn
+++ b/Stages/UI/pause_menu/pause_menu.tscn
@@ -47,10 +47,6 @@ horizontal_alignment = 1
 layout_mode = 2
 text = "Resume"
 
-[node name="TechTreeButton" type="Button" parent="VBoxContainer"]
-layout_mode = 2
-text = "Tech Tree"
-
 [node name="AchievementsButton" type="Button" parent="VBoxContainer"]
 layout_mode = 2
 text = "Achievements"
@@ -72,7 +68,6 @@ layout_mode = 2
 text = "Quit"
 
 [connection signal="pressed" from="VBoxContainer/ResumeButton" to="." method="_on_resume_pressed"]
-[connection signal="pressed" from="VBoxContainer/TechTreeButton" to="." method="_on_tech_tree_pressed"]
 [connection signal="pressed" from="VBoxContainer/AchievementsButton" to="." method="_on_achievements_pressed"]
 [connection signal="pressed" from="VBoxContainer/SettingsButton" to="." method="_on_settings_pressed"]
 [connection signal="pressed" from="VBoxContainer/RestartButton" to="." method="_on_restart_pressed"]

--- a/Stages/UI/tech_tree/tech_tree.gd
+++ b/Stages/UI/tech_tree/tech_tree.gd
@@ -4,9 +4,6 @@ class_name UI_TechTree
 ## Tech Tree UI Screen
 ## Displays tech nodes as a visual tree, allows players to unlock techs,
 ## and shows mutually exclusive warnings
-
-signal closed()
-
 const TechNodeCardScene = preload("res://Stages/UI/tech_tree/tech_node_card.tscn")
 
 @onready var scroll_container: ScrollContainer = $Panel/MarginContainer/VBoxContainer/ScrollContainer
@@ -24,6 +21,9 @@ var selected_tech_id: String = ""
 var tech_node_cards: Dictionary = {} # tech_id -> UI_TechNodeCard
 
 func _ready() -> void:
+  # Connect to GameManager state changes
+  GameManager.game_state_changed.connect(_on_game_state_changed)
+
   # Connect to TechTreeManager signals
   TechTreeManager.tech_unlocked.connect(_on_tech_unlocked)
   TechTreeManager.tech_locked.connect(_on_tech_locked)
@@ -40,6 +40,15 @@ func _ready() -> void:
   _refresh_tech_tree()
   
   MyLogger.info("TechTree", "Tech Tree UI initialized")
+
+func _on_game_state_changed(new_state: GameManager.GameState) -> void:
+  match new_state:
+    GameManager.GameState.IN_TECH_TREE:
+      visible = true
+      # Focus the close button for keyboard navigation
+      close_button.grab_focus()
+    GameManager.GameState.PLAYING:
+      visible = false
 
 ## Handle unhandled key inputs (ESC to close)
 func _unhandled_key_input(event: InputEvent) -> void:
@@ -257,5 +266,6 @@ func _on_tech_locked(tech_id: String) -> void:
 
 ## Handle close button
 func _on_close_pressed() -> void:
-  closed.emit()
-  queue_free()
+  MyLogger.info("TechTree", "Closing Tech Tree UI")
+  if GameManager.current_state == GameManager.GameState.IN_TECH_TREE:
+    GameManager.set_game_state(GameManager.GameState.PLAYING)

--- a/Stages/UI/tech_tree/tech_tree.tscn
+++ b/Stages/UI/tech_tree/tech_tree.tscn
@@ -1,7 +1,13 @@
-[gd_scene load_steps=3 format=3 uid="uid://b7rnv4gqf8q7o"]
+[gd_scene load_steps=5 format=3 uid="uid://b7rnv4gqf8q7o"]
 
 [ext_resource type="Script" uid="uid://bq7n5gj2m4h8x" path="res://Stages/UI/tech_tree/tech_tree.gd" id="1_techtree"]
 [ext_resource type="Theme" uid="uid://b8k2vgj8hxk5r" path="res://Config/ztd_ui_theme.tres" id="2_theme"]
+
+[sub_resource type="InputEventAction" id="InputEventAction_h3ppm"]
+action = &"toggle_in_game_menu"
+
+[sub_resource type="Shortcut" id="Shortcut_k51dw"]
+events = [SubResource("InputEventAction_h3ppm")]
 
 [node name="TechTree" type="Control"]
 layout_mode = 3
@@ -47,6 +53,7 @@ text = "Tech Tree"
 
 [node name="CloseButton" type="Button" parent="Panel/MarginContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
+shortcut = SubResource("Shortcut_k51dw")
 text = "Close"
 
 [node name="ScrollContainer" type="ScrollContainer" parent="Panel/MarginContainer/VBoxContainer"]

--- a/Utilities/Systems/game_manager.gd
+++ b/Utilities/Systems/game_manager.gd
@@ -4,6 +4,7 @@ enum GameState {
   MAIN_MENU, ## When the player is in the main menu
   PLAYING, ## When the player is actively playing a scenario
   IN_GAME_MENU, ## When the in-game menu is open (game is paused)
+  IN_TECH_TREE, ## When the tech tree UI is open
   GAME_OVER, ## When the player has lost any scenario
   VICTORY, ## When the player successfully completes any scenario
   ALL_DONE ## Represents the state after the final scenario is completed
@@ -59,11 +60,15 @@ func get_game_speed() -> float:
 
 
 func toggle_in_game_menu():
-    if current_state == GameState.IN_GAME_MENU:
-        set_game_state(GameState.PLAYING)
-    elif current_state == GameState.PLAYING:
-        pause_game()
-        set_game_state(GameState.IN_GAME_MENU)
+    MyLogger.debug("GameManager", "Toggling in-game menu...")
+    match current_state:
+        GameState.IN_GAME_MENU:
+            set_game_state(GameState.PLAYING)
+        GameState.IN_TECH_TREE:
+            set_game_state(GameState.PLAYING)
+        GameState.PLAYING:
+            pause_game()
+            set_game_state(GameState.IN_GAME_MENU)
 
 ## Returns to the main menu from any game state
 func return_to_main_menu():

--- a/project.godot
+++ b/project.godot
@@ -242,6 +242,11 @@ zoom_slow={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+toggle_tech_tree={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":89,"key_label":0,"unicode":121,"location":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 


### PR DESCRIPTION
This pull request refactors how the Tech Tree UI is accessed and managed in the game. Instead of opening the Tech Tree from the pause menu, it is now toggled directly from gameplay using a new input action. The Tech Tree UI is managed as part of the main UI, and its visibility and state are synchronized with the game's state machine. Several code and scene cleanups were made to support this new flow.

**Tech Tree UI Integration and State Management**

* Added a new `IN_TECH_TREE` state to the `GameManager` state machine to represent when the tech tree is open, and updated related logic to handle transitions in and out of this state. [[1]](diffhunk://#diff-7081d77e1fc782d2fa1130f3c9a2631259d94b803d7aeede7df93a8d4ab8205bR7) [[2]](diffhunk://#diff-7081d77e1fc782d2fa1130f3c9a2631259d94b803d7aeede7df93a8d4ab8205bL62-R69)
* The Tech Tree UI is now instantiated as part of the main UI scene (`ui.tscn`) and toggled via a new input action (`toggle_tech_tree`), rather than being opened from the pause menu. [[1]](diffhunk://#diff-039baea10ca315644576058b3b671ee0787d4e61c7b9066e08f47eacdfa9901aL1-R6) [[2]](diffhunk://#diff-039baea10ca315644576058b3b671ee0787d4e61c7b9066e08f47eacdfa9901aR115-R118) [[3]](diffhunk://#diff-1992cd07f16ae74524cda95df9ee40f67b39d6a145e47496a76811908ed3eb5fR15-R16) [[4]](diffhunk://#diff-1992cd07f16ae74524cda95df9ee40f67b39d6a145e47496a76811908ed3eb5fR52-R60) [[5]](diffhunk://#diff-88c173602c6c7ccaaba6f408d21c235bda4d6884e30e71e73e1b07b9f93ad7b6R245-R249)
* The Tech Tree UI listens for game state changes and shows/hides itself accordingly, focusing the close button when opened. [[1]](diffhunk://#diff-3a62dde8d97b729014442bd8cc4d3e564b37a394dec8cc4fa02110d8f7834e77R24-R26) [[2]](diffhunk://#diff-3a62dde8d97b729014442bd8cc4d3e564b37a394dec8cc4fa02110d8f7834e77R44-R52) [[3]](diffhunk://#diff-3a62dde8d97b729014442bd8cc4d3e564b37a394dec8cc4fa02110d8f7834e77L260-R271)

**Pause Menu and Scene Cleanup**

* Removed the Tech Tree button and related logic from the pause menu, simplifying the pause menu's code and scene files. [[1]](diffhunk://#diff-ce2cf0a047be160555bc041b4b968fc9b9e83aac7736b7040f9ac757f08dfc9aL5-L17) [[2]](diffhunk://#diff-ce2cf0a047be160555bc041b4b968fc9b9e83aac7736b7040f9ac757f08dfc9aL38-L73) [[3]](diffhunk://#diff-6b8976536489d8344036e7563dd22e61608683f4f91c52e01fda8e0480f345d6L50-L53) [[4]](diffhunk://#diff-6b8976536489d8344036e7563dd22e61608683f4f91c52e01fda8e0480f345d6L75)

**UI and Usability Improvements**

* Added a keyboard shortcut (same as the in-game menu) to the Tech Tree close button for improved accessibility. [[1]](diffhunk://#diff-c42b615794b2ccc406e56015f1a4d3a7f5d9f7bf20db6b447942c16f2ba7d963L1-R11) [[2]](diffhunk://#diff-c42b615794b2ccc406e56015f1a4d3a7f5d9f7bf20db6b447942c16f2ba7d963R56)
* Minor adjustment to a UI element's offset for consistency.

**Small Gameplay Logic Fix**

* Fixed the pause button handler to only toggle pause if the game is currently playing, preventing unintended state changes.