### PR TITLE
Fix: update wall cost and increase hitpoints for crates to enhance gameplay balance

### DIFF
--- a/Config/Obstacles/wall.tres
+++ b/Config/Obstacles/wall.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ObstacleTypeResource" load_steps=4 format=3 uid="uid://dw6tfvlsi8cup"]
+[gd_resource type="Resource" script_class="Resource_ObstacleType" format=3 uid="uid://dw6tfvlsi8cup"]
 
 [ext_resource type="Script" uid="uid://vy1lf2kd14dr" path="res://Config/Obstacles/obstacle_type_resource.gd" id="1_cwuf0"]
 [ext_resource type="Texture2D" uid="uid://bgkj5scgyuo2e" path="res://Assets/Icons/new_placeholder_texture_2d.tres" id="1_vdyj0"]
@@ -11,9 +11,7 @@ name = "Stacked Crates"
 description = "A very weak wall to redirect enemies"
 icon = ExtResource("1_vdyj0")
 color = Color(1, 0.129412, 1, 1)
-category = 0
-is_offensive = false
-cost = 10
+cost = 1
 scene = ExtResource("2_vdyj0")
 required_tech_ids = Array[String](["ob_crates"])
 metadata/_custom_type_script = "uid://vy1lf2kd14dr"

--- a/Entities/Obstacles/Concrete/basic_turret/basic_turret.tscn
+++ b/Entities/Obstacles/Concrete/basic_turret/basic_turret.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://bl5g2v8n3jkph"]
+[gd_scene format=3 uid="uid://bl5g2v8n3jkph"]
 
 [ext_resource type="PackedScene" uid="uid://dhxe3f6ho8qma" path="res://Entities/Obstacles/Templates/shooting_obstacle/shooting_obstacle.tscn" id="1_turret"]
 [ext_resource type="Script" uid="uid://0yy8udbhaakj" path="res://Entities/Obstacles/Concrete/basic_turret/basic_turret.gd" id="2_6y5ob"]
@@ -67,7 +67,7 @@ _data = {
 &"idle": SubResource("Animation_6y5ob")
 }
 
-[node name="BasicTurret" node_paths=PackedStringArray("attack_particle_system", "mesh_instances") instance=ExtResource("1_turret")]
+[node name="BasicTurret" unique_id=693839905 node_paths=PackedStringArray("attack_particle_system", "mesh_instances") instance=ExtResource("1_turret")]
 script = ExtResource("2_6y5ob")
 rotation_speed = 360.0
 idle_animation = "idle"
@@ -78,16 +78,16 @@ detection_interval = 0.5
 mesh_instances = [NodePath("turret/TurretBase/Leg_000"), NodePath("turret/TurretBase/Leg_001"), NodePath("turret/TurretBase/Leg_002"), NodePath("turret/TurretBase/Screw"), NodePath("turret/TurretBase/ScrewBase"), NodePath("turret/TurretBase/Table"), NodePath("turret/TurretYaw/Top/Barrel"), NodePath("turret/TurretYaw/Top/BarrelStraps")]
 
 [node name="Attack" parent="." index="1"]
-damage_amount = 1
+damage_amount = 3.0
 attack_speed = 0.75
 damage_source = "turret"
 hit_sound = 2
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="." index="2"]
+[node name="CollisionShape3D" type="CollisionShape3D" parent="." index="2" unique_id=765644085]
 transform = Transform3D(1.74, 0, 0, 0, 1.74, 0, 0, 0, 1.74, 0.234956, 1.8958529, 0.0292969)
 shape = SubResource("BoxShape3D_sl1jc")
 
-[node name="turret" parent="." index="4" instance=ExtResource("3_cvjpm")]
+[node name="turret" parent="." index="4" unique_id=1882957817 instance=ExtResource("3_cvjpm")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.022, -0.93759286, 0.036)
 
 [node name="Leg_000" parent="turret/TurretBase" index="0"]
@@ -111,7 +111,7 @@ transform = Transform3D(0.27080587, 0, 0, 0, 0.052019835, 0, 0, 0, 0.27080587, -
 [node name="Barrel" parent="turret/TurretYaw/Top" index="0"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.11129147, 1.1795998, 0.0047358274)
 
-[node name="GPUParticles3D" type="GPUParticles3D" parent="turret/TurretYaw/Top/Barrel" index="0"]
+[node name="GPUParticles3D" type="GPUParticles3D" parent="turret/TurretYaw/Top/Barrel" index="0" unique_id=1721422763]
 transform = Transform3D(-4.371139e-08, 0, 1, 0, 1, 0, -1, 0, -4.371139e-08, 1.3402462, 0, 0)
 emitting = false
 amount = 90
@@ -126,13 +126,11 @@ draw_pass_1 = SubResource("QuadMesh_3mut8")
 [node name="BarrelStraps" parent="turret/TurretYaw/Top" index="1"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.11129147, 1.1795998, 0.0047358274)
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="." index="5"]
-libraries = {
-&"": SubResource("AnimationLibrary_2a5gv")
-}
-autoplay = "idle"
+[node name="AnimationPlayer" type="AnimationPlayer" parent="." index="5" unique_id=2046900780]
+libraries/ = SubResource("AnimationLibrary_2a5gv")
+autoplay = &"idle"
 
-[node name="Component_IdleSounds" type="Node3D" parent="." index="7" node_paths=PackedStringArray("audio_player")]
+[node name="Component_IdleSounds" type="Node3D" parent="." index="7" unique_id=1302254347 node_paths=PackedStringArray("audio_player")]
 script = ExtResource("4_cvjpm")
 idle_sound = 3
 audio_player = NodePath("../AudioStreamPlayer3D")

--- a/Entities/Obstacles/Concrete/crates.tscn
+++ b/Entities/Obstacles/Concrete/crates.tscn
@@ -17,7 +17,7 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.0152402, 1.0123842, -0.281
 
 [node name="Health" parent="." index="1"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.0152402, 0.4258511, 0)
-hitpoints = 5
+hitpoints = 10
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="." index="2" unique_id=846593028]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.15926981, 1.9883511, -0.129532)


### PR DESCRIPTION
This pull request makes several adjustments to obstacle configuration and entity properties, primarily to rebalance gameplay and improve data consistency. The most notable changes are grouped below by theme.

**Gameplay Balance Adjustments:**

* Increased the `damage_amount` of the `Attack` node in `basic_turret.tscn` from 1 to 3.0, making the basic turret significantly stronger.
* Increased the `hitpoints` for the `Health` node in `crates.tscn` from 5 to 10, making crates more durable.
* Reduced the `cost` of the wall obstacle in `wall.tres` from 10 to 1, making it much cheaper to deploy.

**Data Consistency and Metadata Updates:**

* Changed the script class of the wall obstacle resource in `wall.tres` from `ObstacleTypeResource` to `Resource_ObstacleType`, aligning with naming conventions.
* Added `unique_id` attributes to various nodes in `basic_turret.tscn` for improved identification and serialization. [[1]](diffhunk://#diff-09bcffd9c41fbaf3c78953277802a2ba2d6468237dee8d97543ac882843920daL70-R70) [[2]](diffhunk://#diff-09bcffd9c41fbaf3c78953277802a2ba2d6468237dee8d97543ac882843920daL81-R90) [[3]](diffhunk://#diff-09bcffd9c41fbaf3c78953277802a2ba2d6468237dee8d97543ac882843920daL114-R114) [[4]](diffhunk://#diff-09bcffd9c41fbaf3c78953277802a2ba2d6468237dee8d97543ac882843920daL129-R133)

These changes collectively rebalance obstacle strength and cost, and improve the structure and clarity of entity data.