### PR TITLE
Add script to apply production-safe settings before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,11 @@ jobs:
           mkdir -v -p ~/.local/share/godot/export_templates/
           mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
 
+      - name: Apply release settings
+        run: |
+          cd $PROJECT_PATH
+          bash scripts/apply_release_settings.sh project.godot
+
       - name: Build ${{ matrix.platform.name }}
         run: |
           mkdir -v -p build/${{ matrix.platform.directory }}

--- a/scripts/apply_release_settings.sh
+++ b/scripts/apply_release_settings.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# apply_release_settings.sh
+#
+# Patches project.godot to enforce production-safe settings before a release
+# build. Run this script from the repository root before invoking
+# `godot --export-release`.
+#
+# Idempotent: safe to run multiple times.
+
+set -euo pipefail
+
+PROJECT_FILE="${1:-project.godot}"
+
+if [[ ! -f "$PROJECT_FILE" ]]; then
+  echo "ERROR: project file not found: $PROJECT_FILE" >&2
+  exit 1
+fi
+
+echo "Applying release settings to $PROJECT_FILE ..."
+
+# ── [zom_nom_defense] debug flags ────────────────────────────────────────────
+sed -i \
+  's|^debug/show_debug_panel=.*|debug/show_debug_panel=false|' \
+  "$PROJECT_FILE"
+
+sed -i \
+  's|^debug/bypass_tech_requirements=.*|debug/bypass_tech_requirements=false|' \
+  "$PROJECT_FILE"
+
+# ── [twitcher] log levels ─────────────────────────────────────────────────────
+# Lower all twitcher log channels from "debug" to "warn" for release.
+for key in TwitchAuth TwitchAPI TwitchService; do
+  sed -i \
+    "s|^logs/${key}=\"debug\"|logs/${key}=\"warn\"|" \
+    "$PROJECT_FILE"
+done
+
+# Http log level: "info" → "warn"
+sed -i \
+  's|^logs/Http="info"|logs/Http="warn"|' \
+  "$PROJECT_FILE"
+
+echo "Done. Release settings applied."


### PR DESCRIPTION
This pull request introduces a new script to automate the application of production-safe settings to the `project.godot` file before release builds. It also updates the release workflow to invoke this script, ensuring consistent and safe configuration for production releases.

**Release automation and configuration:**

* Added a new script, `scripts/apply_release_settings.sh`, which patches `project.godot` to enforce production-safe settings such as disabling debug panels, disallowing bypass of tech requirements, and lowering log levels for various channels from "debug"/"info" to "warn". The script is idempotent and validates the presence of the target file.
* Updated the release workflow in `.github/workflows/release.yml` to run the new script before building release artifacts, ensuring that release settings are always applied during CI/CD.